### PR TITLE
feat(DAPPBrowser): Websocket awaits connected and reconnects

### DIFF
--- a/src/DAPPBrowser/index.tsx
+++ b/src/DAPPBrowser/index.tsx
@@ -325,7 +325,10 @@ export class DAPPBrowser extends React.Component<DAPPBrowserProps, DAPPBrowserSt
             delete this.websocket;
         }
 
-        this.websocket = new SmartWebsocket(chainConfig.nodeURL);
+        this.websocket = new SmartWebsocket(chainConfig.nodeURL, {
+            reconnect: true,
+            reconnectMaxAttempts: Infinity,
+        });
         this.websocket.on("message", message => {
             this.sendMessageToDAPP(message);
         });


### PR DESCRIPTION
One possible easy solution for using a Websocket and reconnects on demand if needed.

It differs from what was asked since there is no queue, but it will await the first succeeding reconnection.
It only awaits a connected WS instead of throwing an error.
If all reconnection attempts fails, it will raise an error.
If websocket disconnects (or stopped reconnecting), next send will try reconnect anyway.
It implements a delay between reconnection attempts.